### PR TITLE
Added python3 support.

### DIFF
--- a/pydeep.c
+++ b/pydeep.c
@@ -4,6 +4,29 @@
 
 #define PYDEEP_VERSION  "0.2"
 
+struct module_state {
+    PyObject *error;
+};
+
+#if PY_MAJOR_VERSION >= 3
+#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+#else
+#define GETSTATE(m) (&_state)
+static struct module_state _state;
+#endif
+
+static PyObject *
+error_out(PyObject *m) {
+    struct module_state *st = GETSTATE(m);
+    PyErr_SetString(st->error, "something bad happened");
+    return NULL;
+}
+
+static PyMethodDef pydeep_methods[] = {
+    {"error_out", (PyCFunction)error_out, METH_NOARGS, NULL},
+    {NULL, NULL}
+};
+
 static PyObject *pydeepError;
 
 static PyObject * pydeep_hash_file(PyObject *self, PyObject *args){
@@ -42,7 +65,7 @@ static PyObject * pydeep_hash_file(PyObject *self, PyObject *args){
         PyErr_SetString(pydeepError, "Error in fuzzy_hash!");
         return NULL;
     }
-    ssdeepHash = PyString_FromString(hashResult);
+    ssdeepHash = PyBytes_FromString(hashResult);
     free(hashResult);
     fclose(inputFile);
     return ssdeepHash;
@@ -67,7 +90,7 @@ static PyObject * pydeep_hash_buf(PyObject *self, PyObject *args){
         return NULL;
     }
 
-    inputStringBuffer = PyString_FromStringAndSize(inputBuffer, stringSize);
+    inputStringBuffer = PyBytes_FromStringAndSize(inputBuffer, stringSize);
 
     ret = fuzzy_hash_buf((unsigned char*)inputBuffer, (uint32_t)stringSize, hashResult);
     if (ret !=0 ){
@@ -75,7 +98,7 @@ static PyObject * pydeep_hash_buf(PyObject *self, PyObject *args){
         PyErr_SetString(pydeepError, "Error in fuzzy_hash!");
         return NULL;
     }
-    ssdeepHash = PyString_FromString( hashResult );
+    ssdeepHash = PyBytes_FromString( hashResult );
     free(hashResult);
     return ssdeepHash;
 }
@@ -84,12 +107,16 @@ static PyObject * pydeep_compare(PyObject *self, PyObject *args){
     char *ssdeepHash1= NULL;
     char *ssdeepHash2= NULL;
     int ret;
+#if PY_MAJOR_VERSION >= 3
+    if (!PyArg_ParseTuple(args, "yy", &ssdeepHash1, &ssdeepHash2)){
+#else
     if (!PyArg_ParseTuple(args, "ss", &ssdeepHash1, &ssdeepHash2)){
+#endif
         return NULL;
     }
     ret = fuzzy_compare(ssdeepHash1, ssdeepHash2);
     if (ret < 0){
-        PyErr_SetString(pydeepError, "Error in fuzzy compare");
+        PyErr_SetString(pydeepError, "Error in fuzzy compare!");
         return NULL;
     }
     return Py_BuildValue("i", ret);
@@ -104,13 +131,52 @@ static PyMethodDef pydeepMethods[] = {
     {NULL,  NULL}
 };
 
-// Initialization
+#if PY_MAJOR_VERSION >= 3
+
+static int pydeep_traverse(PyObject *m, visitproc visit, void *arg) {
+    Py_VISIT(GETSTATE(m)->error);
+    return 0;
+}
+
+static int pydeep_clear(PyObject *m) {
+    Py_CLEAR(GETSTATE(m)->error);
+    return 0;
+}
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "pydeep",
+    NULL,
+    sizeof(struct module_state),
+    pydeepMethods,
+    NULL,
+    pydeep_traverse,
+    pydeep_clear,
+    NULL
+};
+
+#define INITERROR return NULL
+#else
+#define INITERROR return
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+PyObject *
+PyInit_pydeep(void)
+#else
 void initpydeep(void)
+#endif
 {
-    PyObject *pydeep;
-    pydeep = Py_InitModule3("pydeep", pydeepMethods, "C/Python bindings for ssdeep [ssdeep.sourceforge.net]");
+#if PY_MAJOR_VERSION >= 3
+    PyObject *pydeep = PyModule_Create(&moduledef);
+#else
+    PyObject *pydeep = Py_InitModule3("pydeep", pydeepMethods, "C/Python bindings for ssdeep [ssdeep.sourceforge.net]");
+#endif
     pydeepError = PyErr_NewException("pydeep.Error", NULL, NULL);
     Py_INCREF(pydeepError);
     PyModule_AddObject(pydeep, "error", pydeepError);
     PyModule_AddStringConstant(pydeep, "__version__", PYDEEP_VERSION);
+#if PY_MAJOR_VERSION >= 3
+    return pydeep;
+#endif
 }

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from distutils.core import setup, Extension
+from distutils.cmd import Command
 
 import os
+import sys
+import os.path as op
 
 def get_version():
     with open(os.path.join(os.path.dirname(__file__), 'pydeep.c'),'r') as f:
@@ -8,6 +11,23 @@ def get_version():
             if "#define PYDEEP_VERSION" in line:
                 return line.split()[-1].strip('"')
 
+class TestCommand(Command):
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        import subprocess
+        os.chdir(op.join(op.dirname(op.abspath(__file__)), "tests"))
+        errno = subprocess.call([sys.executable, 'test.py'])
+        if errno != 0:
+            raise SystemExit(errno)
+        else:
+            os.chdir("..")
 
 setup(
     name = "pydeep",
@@ -25,4 +45,7 @@ setup(
         library_dirs = ["/usr/local/lib/",],
         include_dirs = ["/usr/local/include/",],
         ) ],
+    cmdclass={
+        'test': TestCommand
+    },
 )

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,13 +1,17 @@
+import sys
+import io
+import glob
+sys.path.insert(0, glob.glob('../build/lib.*-' + str(sys.version_info[0]) + '.*')[0])
 import pydeep
 file1 = 'calc.exe'
 file2 = 'notepad.exe'
 file3 = 'bc'
-file1hash = '1536:JEl14rQcWAkN7GAlqbkfAGQGV8aMbrNyrf1w+noPvLV6eBsCXKc:JYmZWXyaiedMbrN6pnoXL1BsC'
-file2hash = '1536:0awOnbNQKLjWDyy1o5RefYMJUEbooPRrKKRl1P3:0YNQKPWDyDRefVJltZrpRl1P3'
-file3hash = '1536:MsjYdR3Bul8hcURWhEcg4/btZzDcQflbCUPEBEh8wkcGDioxMYeo7:TYf8l8htRWA4ztZsGlWUPEBEh8wmxMYe'
-data1 = open(file1).read()
-data2 = open(file2).read()
-data3 = open(file3).read()
+file1hash = b'1536:JEl14rQcWAkN7GAlqbkfAGQGV8aMbrNyrf1w+noPvLV6eBsCXKc:JYmZWXyaiedMbrN6pnoXL1BsC'
+file2hash = b'1536:0awOnbNQKLjWDyy1o5RefYMJUEbooPRrKKRl1P3:0YNQKPWDyDRefVJltZrpRl1P3'
+file3hash = b'1536:MsjYdR3Bul8hcURWhEcg4/btZzDcQflbCUPEBEh8wkcGDioxMYeo7:TYf8l8htRWA4ztZsGlWUPEBEh8wmxMYe'
+data1 = io.open(file1, 'rb').read()
+data2 = io.open(file2, 'rb').read()
+data3 = io.open(file3, 'rb').read()
 assert len(data1) == 114688, "File length error"
 assert len(data2) ==  69120, "File length error"
 assert len(data3) ==  77168, "File length error"
@@ -24,4 +28,4 @@ assert hash1 == file1hash, "Error hashing file1"
 assert hash2 == file2hash, "Error hashing file2"
 assert hash3 == file3hash, "Error hashing file3"
 assert pydeep.compare(hash1,hash2) == 0, "Error fuzzy compare value"
-print 'Stuff looks fine..' 
+print('Stuff looks fine..')


### PR DESCRIPTION
The most substantial changes were due to the module initialization changes in python3; also some string->binary changes.  Based most of my changes on on
https://docs.python.org/3/howto/cporting.html and a few random projects I reviewed.  The code remains python2-compatible.  Also updated test.py, and added support for 'python[23] setup.py test' after build.