### PR TITLE
Increment pydeep version to match latest release

### DIFF
--- a/pydeep.c
+++ b/pydeep.c
@@ -3,7 +3,7 @@
 #include <unistd.h>
 #include <bytesobject.h>
 
-#define PYDEEP_VERSION  "0.2"
+#define PYDEEP_VERSION  "0.4"
 
 static PyObject *pydeepError;
 


### PR DESCRIPTION
I can't tell the real version when using pip and pypi because both 0.4 and 0.2 report themselves as 0.2 because of this line.