### PR TITLE
Non functional updates: test with ssdeep-2.14 and Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
     - 3.3
     - 3.4
     - 3.5 
-    - 3.7 
+    - 3.6 
+    - 3.7-dev 
 before_install:
     - sudo apt-get update -qq
     - sudo apt-get install python-dev -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,13 @@ python:
     - 3.3
     - 3.4
     - 3.5 
+    - 3.7 
 before_install:
     - sudo apt-get update -qq
     - sudo apt-get install python-dev -qq
-    - wget http://downloads.sourceforge.net/project/ssdeep/ssdeep-2.13/ssdeep-2.13.tar.gz
-    - tar -zxvf ssdeep-2.13.tar.gz
-    - cd ssdeep-2.13
+    - wget https://github.com/ssdeep-project/ssdeep/releases/download/release-2.14/ssdeep-2.14.tar.gz
+    - tar -zxvf ssdeep-2.14.tar.gz
+    - cd ssdeep-2.14
     - ./configure && make
     - sudo make install
     - sudo ldconfig

--- a/README.md
+++ b/README.md
@@ -15,11 +15,8 @@ pydeep.hash_file('/path/to/file')
 pydeep.compare('hash1','hash2')
 ```
 
-### Releases
-* For Python 2.5 and older, use the [0.4 release](https://github.com/kbandla/pydeep/releases/tag/0.4)
-* For Python 2.6+ and Python 3.3+, use the master branch
-
 ### Tested On
+* Debian 9 - x86_64
 * OSX 10.10 - x86_64
 * OSX 10.9 - x86_64
 * OSX 10.8 - x86_64
@@ -28,6 +25,7 @@ pydeep.compare('hash1','hash2')
 * Debian 7 - x86_64
 
 ### Tested Against
+* ssdeep-2.14
 * ssdeep-2.13
 * ssdeep-2.11.1
 * ssdeep-2.10


### PR DESCRIPTION
The pydeep module itself is not touched, but tested to work against ssdeep-2.14 and python 3.7