### PR TITLE
Migrate distutils to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-from distutils.core import setup, Extension
-from distutils.cmd import Command
+from setuptools import setup, Command, Extension
 
 import os
 import sys


### PR DESCRIPTION
Moving from distutils to setuptools allows one to create a pre-complied wheel package. This is a drop in replacement. 

I did this for docker multi-stage builds, allowing me to build the package and just include the wheel package in my final docker container. 